### PR TITLE
github上からレビュアーをアサインできるようにする

### DIFF
--- a/src/reviewer-lotto.coffee
+++ b/src/reviewer-lotto.coffee
@@ -42,7 +42,7 @@ module.exports = (robot) ->
     msgs.push "#{login}, #{count}" for login, count of stats
     msg.reply msgs.join "\n"
 
-  robot.hear /<a.*>(.+)<\/a> commented on <a.*>pull request (.+)<\/a> of <a.*>kaizenplatform\/(.+)<\/a>: hubot reviewer( polite)?/i, (msg) ->
+  robot.hear /<a.*>(.+)<\/a> commented on <a.*>pull request (.+)<\/a> of <a.*>(.+)\/(.+)<\/a>: hubot reviewer( polite)?/i, (msg) ->
     if !noticeRoom?
       return
     from = msg.match[1]

--- a/src/reviewer-lotto.coffee
+++ b/src/reviewer-lotto.coffee
@@ -42,7 +42,7 @@ module.exports = (robot) ->
     msgs.push "#{login}, #{count}" for login, count of stats
     msg.reply msgs.join "\n"
 
-  robot.hear /<a.*>(.+)<\/a> commented on <a.*>pull request (.+)<\/a> of <a.*>(.+)\/(.+)<\/a>: hubot reviewer( polite)?/i, (msg) ->
+  robot.hear /<a.*>(.+)<\/a> commented on <a.*>pull request (.+)<\/a> of <a.*>.+\/(.+)<\/a>: hubot reviewer( polite)?/i, (msg) ->
     if !noticeRoom?
       return
     from = msg.match[1]

--- a/src/reviewer-lotto.coffee
+++ b/src/reviewer-lotto.coffee
@@ -23,6 +23,7 @@ module.exports = (robot) ->
   ghOrg         = process.env.HUBOT_GITHUB_ORG
   ghReviwerTeam = process.env.HUBOT_GITHUB_REVIEWER_TEAM
   ghWithAvatar  = process.env.HUBOT_GITHUB_WITH_AVATAR
+  noticeRoom    = process.env.HUBOT_NOTICE_ROOM
 
   STATS_KEY     = 'reviewer-lotto-stats'
 
@@ -41,15 +42,24 @@ module.exports = (robot) ->
     msgs.push "#{login}, #{count}" for login, count of stats
     msg.reply msgs.join "\n"
 
+  robot.hear /<a.*>(.+)<\/a> commented on <a.*>pull request (.+)<\/a> of <a.*>kaizenplatform\/(.+)<\/a>: hubot reviewer( polite)?/i, (msg) ->
+    from = msg.match[1]
+    pr = msg.match[2]
+    repo = msg.match[3]
+    polite = msg.match[4]?
+    lot(repo, pr, polite, from)
+
   robot.respond /reviewer for ([\w-\.]+) (\d+)( polite)?$/i, (msg) ->
     repo = msg.match[1]
     pr   = msg.match[2]
     polite = msg.match[3]?
+    lot(repo, pr, polite, nil)
+
+  lot = (repo, pr, polite, from) ->
     prParams =
       user: ghOrg
       repo: repo
       number: pr
-
     gh = new GitHubApi version: "3.0.0"
     gh.authenticate {type: "oauth", token: ghToken}
 
@@ -107,7 +117,12 @@ module.exports = (robot) ->
       (ctx, cb) ->
         {reviewer, issue} = ctx
         messages = []
-        msg.reply "#{reviewer.login} has been assigned for #{issue.html_url} as a reviewer"
+        message = "#{reviewer.login} has been assigned for #{issue.html_url} as a reviewer"
+        if from?
+          robot.messageRoom noticeRoom, "@#{from} #{message}"
+        else
+          msg.reply message
+
         if ghWithAvatar
           # hipchat needs image-ish url to display inline image
           msg.send "#{reviewer.avatar_url}".replace(/(#.*|$)/, '#.png')

--- a/src/reviewer-lotto.coffee
+++ b/src/reviewer-lotto.coffee
@@ -43,6 +43,8 @@ module.exports = (robot) ->
     msg.reply msgs.join "\n"
 
   robot.hear /<a.*>(.+)<\/a> commented on <a.*>pull request (.+)<\/a> of <a.*>kaizenplatform\/(.+)<\/a>: hubot reviewer( polite)?/i, (msg) ->
+    if !noticeRoom?
+      return
     from = msg.match[1]
     pr = msg.match[2]
     repo = msg.match[3]
@@ -118,14 +120,16 @@ module.exports = (robot) ->
         {reviewer, issue} = ctx
         messages = []
         message = "#{reviewer.login} has been assigned for #{issue.html_url} as a reviewer"
+        # hipchat needs image-ish url to display inline image
+        avatar = "#{reviewer.avatar_url}".replace(/(#.*|$)/, '#.png')
         if from?
           robot.messageRoom noticeRoom, "@#{from} #{message}"
+          if ghWithAvatar
+            robot.messageRoom noticeRoom, avatar
         else
           msg.reply message
-
-        if ghWithAvatar
-          # hipchat needs image-ish url to display inline image
-          msg.send "#{reviewer.avatar_url}".replace(/(#.*|$)/, '#.png')
+          if ghWithAvatar
+            msg.send avatar
 
         # update stats
         stats = (robot.brain.get STATS_KEY) or {}


### PR DESCRIPTION
#### 目的
hipchatに「hubot reviewer ...」って書くのめんどくさい＆プルリクのページから直接レビュアーアサインしたい

#### 機能
プルリクページに「hubot reviewer」とコメントするだけで、
hipchatに通知されるGithub commits↓に反応して、
![2014-06-17 3 07 23](https://cloud.githubusercontent.com/assets/792873/3291127/3558b330-f581-11e3-9b9d-4a62b2f62db2.png)
該当のプルリクに自動でレビュアーをアサインしてくれる（たぶん）
※動かしかたがよくわからなかったので動作確認等はしていない

#### 設定等
1. hubotを、Github Commitsの部屋にも待機させる
2. HUBOT_NOTICE_ROOMに通知する部屋jidを指定（Github commitsで返信しても気がつかないので）
